### PR TITLE
Use popup controller to make share work on ipads

### DIFF
--- a/ios/Classes/SwiftFlutterSharePlugin.swift
+++ b/ios/Classes/SwiftFlutterSharePlugin.swift
@@ -98,6 +98,15 @@ public class SwiftFlutterSharePlugin: NSObject, FlutterPlugin {
             activityViewController.setValue(title, forKeyPath: "subject");
         }
 
+        // For iPads, fix issue where Exception is thrown by using a popup instead
+        if UIDevice.current.userInterfaceIdiom == .pad {
+          activityViewController.popoverPresentationController?.sourceView = UIApplication.topViewController()?.view
+          if let view = UIApplication.topViewController()?.view {
+              activityViewController.popoverPresentationController?.permittedArrowDirections = []
+              activityViewController.popoverPresentationController?.sourceRect = CGRect(x: view.bounds.midX, y: view.bounds.midY, width: 0, height: 0)
+          }
+        }
+
         DispatchQueue.main.async {
             UIApplication.topViewController()?.present(activityViewController, animated: true, completion: nil)
         }


### PR DESCRIPTION
Fix for: https://github.com/lubritto/flutter_share/issues/8

This is probably not the best solution, but it allows sharing on iPads and iPhones without an exception being thrown. 