### PR TITLE
filetype is added for android to cut down options to only which suppo…

### DIFF
--- a/android/src/main/java/com/example/fluttershare/FlutterSharePlugin.java
+++ b/android/src/main/java/com/example/fluttershare/FlutterSharePlugin.java
@@ -103,6 +103,7 @@ public class FlutterSharePlugin implements MethodCallHandler {
             String title = call.argument("title");
             String text = call.argument("text");
             String filePath = call.argument("filePath");
+            String fileType = call.argument("fileType");
             String chooserTitle = call.argument("chooserTitle");
 
             if (filePath == null || filePath.isEmpty())
@@ -120,7 +121,7 @@ public class FlutterSharePlugin implements MethodCallHandler {
             intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
             intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             intent.setAction(Intent.ACTION_SEND);
-            intent.setType("*/*");
+            intent.setType(fileType);
             intent.putExtra(Intent.EXTRA_SUBJECT, title);
             intent.putExtra(Intent.EXTRA_TEXT, text);
             intent.putExtra(Intent.EXTRA_STREAM, fileUri);

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -48,6 +48,7 @@ class MyApp extends StatelessWidget {
     await FlutterShare.shareFile(
       title: 'Compartilhar comprovante',
       filePath: localPath,
+      fileType: 'image/png'
     );
   }
 

--- a/lib/flutter_share.dart
+++ b/lib/flutter_share.dart
@@ -48,7 +48,8 @@ class FlutterShare {
       {@required String title,
       @required String filePath,
       String text,
-      String chooserTitle}) async {
+      String chooserTitle,
+      String fileType = '*/*'}) async {
     assert(title != null && title.isNotEmpty);
     assert(filePath != null && filePath.isNotEmpty);
 
@@ -63,6 +64,7 @@ class FlutterShare {
       'title': title,
       'text': text,
       'filePath': filePath,
+      'fileType': fileType,
       'chooserTitle': chooserTitle,
     });
 


### PR DESCRIPTION
filetype is added for android to cut down options to only which support this file type.

before :
i was trying to share PDF file.
but didn't get option of default PDF printer.

then:
I was trying to find out why this is happening. then i try to do it in native android and i found that there is an option in intent to set type. when i look in native android code of this plugin. i findout that type was hardcoded to "*/*"

now i have changed hardcoded type to default parameter "*/*" 

so that i can set type to 'application/pdf' 


