### PR TITLE
Prevents image save view controller dismissal issue on iOS 13+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.2+2
+
+* Fix share image top view controller dismissal bug on iOS 13+
+
 ## 1.0.2+1
 
 * Fix Android bug (FileUriExposedException) on new versions with FileProvider implementation (see the readme to configure)

--- a/ios/Classes/SwiftFlutterSharePlugin.swift
+++ b/ios/Classes/SwiftFlutterSharePlugin.swift
@@ -61,7 +61,7 @@ public class SwiftFlutterSharePlugin: NSObject, FlutterPlugin {
         }
 
         DispatchQueue.main.async {
-            UIApplication.topViewController()?.present(activityViewController, animated: true, completion: nil)
+            self.presentActivityView(activityViewController: activityViewController)
         }
 
         return true
@@ -108,10 +108,29 @@ public class SwiftFlutterSharePlugin: NSObject, FlutterPlugin {
         }
 
         DispatchQueue.main.async {
-            UIApplication.topViewController()?.present(activityViewController, animated: true, completion: nil)
+            self.presentActivityView(activityViewController: activityViewController)
         }
         
         return true
+    }
+
+    private func presentActivityView(activityViewController: UIActivityViewController) {
+        // using this fake view controller to prevent this iOS 13+ dismissing the top view when sharing with "Save Image" option
+
+        let fakeViewController = TransparentViewController()
+        fakeViewController.modalPresentationStyle = .overFullScreen
+
+        activityViewController.completionWithItemsHandler = { [weak fakeViewController] _, _, _, _ in
+            if let presentingViewController = fakeViewController?.presentingViewController {
+                presentingViewController.dismiss(animated: false, completion: nil)
+            } else {
+                fakeViewController?.dismiss(animated: false, completion: nil)
+            }
+        }
+
+        UIApplication.topViewController()?.present(fakeViewController, animated: true) { [weak fakeViewController] in
+            fakeViewController?.present(activityViewController, animated: true, completion: nil)
+        }
     }
 }
 
@@ -129,5 +148,12 @@ extension UIApplication {
             return topViewController(controller: presented)
         }
         return controller
+    }
+}
+
+class TransparentViewController: UIViewController {
+    override func viewDidLoad() {
+        view.backgroundColor = UIColor.clear
+        view.isOpaque = false
     }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_share
 description: Simple way to share message, links or files from your flutter app for Android and IOS (Enter to see some gifs).
-version: 1.0.2+1
+version: 1.0.2+2
 author: Lucas Britto <l_demello@hotmail.com>
 homepage: https://github.com/lubritto/flutter_share
 


### PR DESCRIPTION
When sharing a file with the iOS option of "Save image", the iOS dismisses the top view controller of the stack after the image is successfully saved, as described on this StackOverflow thread: https://stackoverflow.com/questions/56903030/ios-13-uiactivityviewcontroller-automatically-present-previous-vc-after-image-sa/61032571#61032571

This PR protects from the behavior with the solution proposed by KDP at the thread, presenting a transparent view to be dismissed by iOS instead of the current screen that the customer is seeing.