### PR TITLE
Bump Android SDK to 29

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
We are bumping android to 29, to avoid download platform and build tools 29 and 29.0.3